### PR TITLE
Add option to choose fields to sync

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,6 @@
   "tasks": {
     "test": "npm install && npm test",
     "build": "npm install",
-    "launch": "npm install && GITHUB_TOKEN={TOKEN} PROJECT_URL=https://github.com/orgs/lemongrasss/projects/227 node src/dependants-sync.js"
+    "launch": "npm install && GITHUB_TOKEN={TOKEN} PROJECT_URL=https://github.com/orgs/lemongrasss/projects/227 SYNC_FIELDS=Initiative node src/dependants-sync.js"
   }
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Automates the synchronization of fields in GitHub Projects between parent issues
 2. Add the following secrets to your repository:
    - `GITHUB_TOKEN` - GitHub token with project access.
    - `PROJECT_URL` - The URL of your GitHub Project.
+   - `SYNC_FIELDS` - Comma-separated list of single select fields to synchronize.
 
 3. The workflow runs every 15 minutes automatically.
 
@@ -19,7 +20,7 @@ Automates the synchronization of fields in GitHub Projects between parent issues
 
 ```bash
 npm install
-GITHUB_TOKEN=your_token PROJECT_URL=https://github.com/orgs/my-org/projects/1 node src/dependants-sync.js
+GITHUB_TOKEN=your_token PROJECT_URL=https://github.com/orgs/my-org/projects/1 SYNC_FIELDS=Initiative,Labels node src/dependants-sync.js
 ```
 
 ## 🧪 Running Tests

--- a/tests/dependants-sync.test.js
+++ b/tests/dependants-sync.test.js
@@ -46,7 +46,8 @@ describe('dependants-sync', () => {
                   name: 'Initiative',
                   options: [
                     { id: 'option-id', name: 'Option' }
-                  ]
+                  ],
+                  __typename: 'ProjectV2SingleSelectField'
                 }
               ]
             },

--- a/tests/integration/dependants-sync.integration.test.js
+++ b/tests/integration/dependants-sync.integration.test.js
@@ -13,6 +13,7 @@ describe("dependants-sync integration tests", () => {
   test("should successfully synchronize fields", async () => {
     process.env.GITHUB_TOKEN = "test-token";
     process.env.PROJECT_URL = "https://github.com/orgs/my-org/projects/1";
+    process.env.SYNC_FIELDS = "Initiative";
 
     const mockGraphql = jest
       .fn()
@@ -26,6 +27,7 @@ describe("dependants-sync integration tests", () => {
                   id: "field-id",
                   name: "Initiative",
                   options: [{ id: "option-id", name: "Option" }],
+                  __typename: "ProjectV2SingleSelectField"
                 },
               ],
             },
@@ -105,11 +107,9 @@ describe("dependants-sync integration tests", () => {
 
     expect(core.info).toHaveBeenCalledWith("Querying project details...");
     expect(core.info).toHaveBeenCalledWith("Found project id: project-id");
+    expect(core.info).toHaveBeenCalledWith("Found fields to sync: Initiative");
     expect(core.info).toHaveBeenCalledWith("Loading all project items...");
     expect(core.info).toHaveBeenCalledWith("Loaded 2 project items.");
-    expect(core.info).toHaveBeenCalledWith(
-      "Found Initiative field with id: field-id"
-    );
     expect(core.info).toHaveBeenCalledWith(
       "Processing project item item-id-1 linked to issue issue-id-1"
     );
@@ -166,13 +166,14 @@ describe("dependants-sync integration tests", () => {
     await run();
 
     expect(core.setFailed).toHaveBeenCalledWith(
-      "Cannot read properties of undefined (reading 'organization')"
+      "Could not find any valid single select fields to sync in the project."
     );
   });
 
   test("should traverse parent issues structure for 3 levels deep", async () => {
     process.env.GITHUB_TOKEN = "test-token";
     process.env.PROJECT_URL = "https://github.com/orgs/my-org/projects/1";
+    process.env.SYNC_FIELDS = "Initiative";
 
     const mockGraphql = jest
       .fn()
@@ -186,6 +187,7 @@ describe("dependants-sync integration tests", () => {
                   id: "field-id",
                   name: "Initiative",
                   options: [{ id: "option-id", name: "Option" }],
+                  __typename: "ProjectV2SingleSelectField"
                 },
               ],
             },
@@ -260,11 +262,9 @@ describe("dependants-sync integration tests", () => {
 
     expect(core.info).toHaveBeenCalledWith("Querying project details...");
     expect(core.info).toHaveBeenCalledWith("Found project id: project-id");
+    expect(core.info).toHaveBeenCalledWith("Found fields to sync: Initiative");
     expect(core.info).toHaveBeenCalledWith("Loading all project items...");
     expect(core.info).toHaveBeenCalledWith("Loaded 1 project items.");
-    expect(core.info).toHaveBeenCalledWith(
-      "Found Initiative field with id: field-id"
-    );
     expect(core.info).toHaveBeenCalledWith(
       "Processing project item item-id-1 linked to issue issue-id-1"
     );
@@ -288,5 +288,191 @@ describe("dependants-sync integration tests", () => {
     );
 
     expect(mockGraphql).toHaveBeenCalledTimes(5);
+  });
+
+  test("should synchronize multiple fields", async () => {
+    process.env.GITHUB_TOKEN = "test-token";
+    process.env.PROJECT_URL = "https://github.com/orgs/my-org/projects/1";
+    process.env.SYNC_FIELDS = "Initiative,Team";
+
+    const mockGraphql = jest
+      .fn()
+      .mockResolvedValueOnce({
+        organization: {
+          projectV2: {
+            id: "project-id",
+            fields: {
+              nodes: [
+                {
+                  id: "field-id-initiative",
+                  name: "Initiative",
+                  options: [{ id: "option-id-initiative", name: "Option" }],
+                  __typename: "ProjectV2SingleSelectField"
+                },
+                {
+                  id: "field-id-team",
+                  name: "Team",
+                  options: [{ id: "option-id-team", name: "Option" }],
+                  __typename: "ProjectV2SingleSelectField"
+                },
+              ],
+            },
+            items: {
+              nodes: [],
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        organization: {
+          projectV2: {
+            items: {
+              nodes: [
+                {
+                  id: "item-id-1",
+                  fieldValues: {
+                    nodes: [],
+                  },
+                  content: {
+                    id: "issue-id-1",
+                  },
+                },
+                {
+                  id: "item-id-2",
+                  fieldValues: {
+                    nodes: [
+                      {
+                        field: {
+                          name: "Initiative",
+                        },
+                        optionId: "option-id-initiative",
+                      },
+                      {
+                        field: {
+                          name: "Team",
+                        },
+                        optionId: "option-id-team",
+                      },
+                    ],
+                  },
+                  content: {
+                    id: "issue-id-2",
+                  },
+                },
+              ],
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null,
+              },
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        node: {
+          id: "issue-id-1",
+          parent: {
+            id: "parent-issue-id-1",
+            issueType: {
+              name: "Initiative",
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        node: {
+          id: "issue-id-2",
+          parent: {
+            id: "parent-issue-id-2",
+            issueType: {
+              name: "Initiative",
+            },
+          },
+        },
+      });
+
+    github.getOctokit.mockReturnValue({
+      graphql: mockGraphql,
+    });
+
+    await run();
+
+    expect(core.info).toHaveBeenCalledWith("Querying project details...");
+    expect(core.info).toHaveBeenCalledWith("Found project id: project-id");
+    expect(core.info).toHaveBeenCalledWith("Found fields to sync: Initiative, Team");
+    expect(core.info).toHaveBeenCalledWith("Loading all project items...");
+    expect(core.info).toHaveBeenCalledWith("Loaded 2 project items.");
+    expect(core.info).toHaveBeenCalledWith(
+      "Processing project item item-id-1 linked to issue issue-id-1"
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      'Parent parent-issue-id-1 has issue type "Initiative"'
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      "Found parent initiative issue with id: parent-issue-id-1"
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      "No project item found for parent initiative issue parent-issue-id-1. Skipping update."
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      "Processing project item item-id-2 linked to issue issue-id-2"
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      'Parent parent-issue-id-2 has issue type "Initiative"'
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      "Found parent initiative issue with id: parent-issue-id-2"
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      "No project item found for parent initiative issue parent-issue-id-2. Skipping update.",
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      "Update process completed for all project items."
+    );
+
+    expect(mockGraphql).toHaveBeenCalledTimes(4);
+  });
+
+  test("should report error for non-single select fields", async () => {
+    process.env.GITHUB_TOKEN = "test-token";
+    process.env.PROJECT_URL = "https://github.com/orgs/my-org/projects/1";
+    process.env.SYNC_FIELDS = "Team,Notes";
+
+    const mockGraphql = jest
+      .fn()
+      .mockResolvedValueOnce({
+        organization: {
+          projectV2: {
+            id: "project-id",
+            fields: {
+              nodes: [
+                {
+                  id: "field-id-team",
+                  name: "Team",
+                  __typename: "ProjectV2TextField"
+                },
+                {
+                  id: "field-id-notes",
+                  name: "Notes",
+                  __typename: "ProjectV2TextField",
+                },
+              ],
+            },
+            items: {
+              nodes: [],
+            },
+          },
+        },
+      });
+
+    github.getOctokit.mockReturnValue({
+      graphql: mockGraphql,
+    });
+
+    await run();
+    
+    expect(core.setFailed).toHaveBeenCalledWith(
+      'Could not find any valid single select fields to sync in the project.'
+    );
   });
 });


### PR DESCRIPTION
Fixes #1

Add option to define which single select fields to synchronize across issues.

* Add `SYNC_FIELDS` environment variable to specify comma-separated fields in `src/dependants-sync.js`.
* Update script to read `SYNC_FIELDS` and synchronize specified fields.
* Add validation to check field types and report errors for non-single select fields.
* Change the order of steps to locate the Initiative field by name before loading all project items with pagination.
* Update `README.md` to include instructions for using the `SYNC_FIELDS` environment variable.
* Add new tests in `tests/dependants-sync.test.js` and `tests/integration/dependants-sync.integration.test.js` to cover the new feature.
* Update existing tests to reflect the changes in `src/dependants-sync.js`.
* Mock `field.__typename` in the tests.

