### PR TITLE
Add option to customize Issue Type

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,6 @@
   "tasks": {
     "test": "npm install && npm test",
     "build": "npm install",
-    "launch": "npm install && GITHUB_TOKEN={TOKEN} PROJECT_URL=https://github.com/orgs/lemongrasss/projects/227 SYNC_FIELDS=Initiative node src/dependants-sync.js"
+    "launch": "npm install && GITHUB_TOKEN={TOKEN} PROJECT_URL=https://github.com/orgs/lemongrasss/projects/227 SYNC_FIELDS=Initiative,Team TOP_PARENT_ISSUE_TYPE=Epic node src/dependants-sync.js"
   }
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Automates the synchronization of fields in GitHub Projects between parent issues
    - `GITHUB_TOKEN` - GitHub token with project access.
    - `PROJECT_URL` - The URL of your GitHub Project.
    - `SYNC_FIELDS` - Comma-separated list of single select fields to synchronize.
+   - `TOP_PARENT_ISSUE_TYPE` - The Issue Type to use to determine the top parent issue (default: `Initiative`).
 
 3. The workflow runs every 15 minutes automatically.
 
@@ -20,7 +21,7 @@ Automates the synchronization of fields in GitHub Projects between parent issues
 
 ```bash
 npm install
-GITHUB_TOKEN=your_token PROJECT_URL=https://github.com/orgs/my-org/projects/1 SYNC_FIELDS=Initiative,Labels node src/dependants-sync.js
+GITHUB_TOKEN=your_token PROJECT_URL=https://github.com/orgs/my-org/projects/1 SYNC_FIELDS=Initiative,Team TOP_PARENT_ISSUE_TYPE=Initiative node src/dependants-sync.js
 ```
 
 ## 🧪 Running Tests

--- a/src/dependants-sync.js
+++ b/src/dependants-sync.js
@@ -173,6 +173,7 @@ async function run() {
      * @returns {Promise<string|null>}
      */
     async function findParentInitiativeIssue(currentId) {
+      const topParentIssueType = process.env.TOP_PARENT_ISSUE_TYPE || "Initiative";
       const query = `
         query ($id: ID!) {
           node(id: $id) {
@@ -226,7 +227,7 @@ async function run() {
         try {
           const parentType = issue.parent.issueType;
           core.info(`Parent ${parent.id} has issue type "${parentType.name}"`);
-          if (parentType.name === "Initiative") {
+          if (parentType.name === topParentIssueType) {
             return parent.id;
           }
         } catch (e) {

--- a/tests/dependants-sync.test.js
+++ b/tests/dependants-sync.test.js
@@ -64,4 +64,40 @@ describe('dependants-sync', () => {
     expect(core.info).toHaveBeenCalledWith('Querying project details...');
     expect(core.info).toHaveBeenCalledWith('Found project id: project-id');
   });
+
+  test('should use TOP_PARENT_ISSUE_TYPE environment variable', async () => {
+    process.env.GITHUB_TOKEN = 'test-token';
+    process.env.PROJECT_URL = 'https://github.com/orgs/my-org/projects/1';
+    process.env.TOP_PARENT_ISSUE_TYPE = 'Epic';
+
+    github.getOctokit.mockReturnValue({
+      graphql: jest.fn().mockResolvedValue({
+        organization: {
+          projectV2: {
+            id: 'project-id',
+            fields: {
+              nodes: [
+                {
+                  id: 'field-id',
+                  name: 'Initiative',
+                  options: [
+                    { id: 'option-id', name: 'Option' }
+                  ],
+                  __typename: 'ProjectV2SingleSelectField'
+                }
+              ]
+            },
+            items: {
+              nodes: []
+            }
+          }
+        }
+      })
+    });
+
+    await run();
+
+    expect(core.info).toHaveBeenCalledWith('Querying project details...');
+    expect(core.info).toHaveBeenCalledWith('Found project id: project-id');
+  });
 });

--- a/tests/integration/dependants-sync.integration.test.js
+++ b/tests/integration/dependants-sync.integration.test.js
@@ -475,4 +475,136 @@ describe("dependants-sync integration tests", () => {
       'Could not find any valid single select fields to sync in the project.'
     );
   });
+
+  test("should use TOP_PARENT_ISSUE_TYPE environment variable in integration test", async () => {
+    process.env.GITHUB_TOKEN = "test-token";
+    process.env.PROJECT_URL = "https://github.com/orgs/my-org/projects/1";
+    process.env.SYNC_FIELDS = "Initiative";
+    process.env.TOP_PARENT_ISSUE_TYPE = "Epic";
+
+    const mockGraphql = jest
+      .fn()
+      .mockResolvedValueOnce({
+        organization: {
+          projectV2: {
+            id: "project-id",
+            fields: {
+              nodes: [
+                {
+                  id: "field-id",
+                  name: "Initiative",
+                  options: [{ id: "option-id", name: "Option" }],
+                  __typename: "ProjectV2SingleSelectField"
+                },
+              ],
+            },
+            items: {
+              nodes: [],
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        organization: {
+          projectV2: {
+            items: {
+              nodes: [
+                {
+                  id: "item-id-1",
+                  fieldValues: {
+                    nodes: [],
+                  },
+                  content: {
+                    id: "issue-id-1",
+                  },
+                },
+                {
+                  id: "item-id-2",
+                  fieldValues: {
+                    nodes: [
+                      {
+                        field: {
+                          name: "Initiative",
+                        },
+                        optionId: "option-id",
+                      },
+                    ],
+                  },
+                  content: {
+                    id: "issue-id-2",
+                  },
+                },
+              ],
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null,
+              },
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        node: {
+          id: "issue-id-1",
+          parent: {
+            id: "parent-issue-id-1",
+            issueType: {
+              name: "Epic",
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        node: {
+          id: "issue-id-2",
+          parent: {
+            id: "parent-issue-id-2",
+            issueType: {
+              name: "Epic",
+            },
+          },
+        },
+      });
+
+    github.getOctokit.mockReturnValue({
+      graphql: mockGraphql,
+    });
+
+    await run();
+
+    expect(core.info).toHaveBeenCalledWith("Querying project details...");
+    expect(core.info).toHaveBeenCalledWith("Found project id: project-id");
+    expect(core.info).toHaveBeenCalledWith("Found fields to sync: Initiative");
+    expect(core.info).toHaveBeenCalledWith("Loading all project items...");
+    expect(core.info).toHaveBeenCalledWith("Loaded 2 project items.");
+    expect(core.info).toHaveBeenCalledWith(
+      "Processing project item item-id-1 linked to issue issue-id-1"
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      'Parent parent-issue-id-1 has issue type "Epic"'
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      "Found parent initiative issue with id: parent-issue-id-1"
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      "No project item found for parent initiative issue parent-issue-id-1. Skipping update."
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      "Processing project item item-id-2 linked to issue issue-id-2"
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      'Parent parent-issue-id-2 has issue type "Epic"'
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      "Found parent initiative issue with id: parent-issue-id-2"
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      "No project item found for parent initiative issue parent-issue-id-2. Skipping update.",
+    );
+    expect(core.info).toHaveBeenCalledWith(
+      "Update process completed for all project items."
+    );
+
+    expect(mockGraphql).toHaveBeenCalledTimes(4);
+  });
 });


### PR DESCRIPTION
Fixes #6

Add option to customize the Issue Type used to determine the top parent issue.

* Add a new environment variable `TOP_PARENT_ISSUE_TYPE` to specify the Issue Type.
* Update `src/dependants-sync.js` to use the `TOP_PARENT_ISSUE_TYPE` environment variable instead of hardcoding "Initiative".
* Update `README.md` to include instructions for setting the `TOP_PARENT_ISSUE_TYPE` environment variable and update the example command.
* Add a test case in `tests/dependants-sync.test.js` to check if the `TOP_PARENT_ISSUE_TYPE` environment variable is used correctly.
* Add an integration test case in `tests/integration/dependants-sync.integration.test.js` to check if the `TOP_PARENT_ISSUE_TYPE` environment variable is used correctly.
* Update `.devcontainer/devcontainer.json` to include `TOP_PARENT_ISSUE_TYPE` in the launch command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lukewar/dependants-sync-action/pull/7?shareId=b27ed777-eacc-458b-b7ef-86769466a64f).